### PR TITLE
Ensure that single characters don't turn into multiple characters when transliterating.

### DIFF
--- a/lib/translighterate.rb
+++ b/lib/translighterate.rb
@@ -17,9 +17,7 @@ module Translighterate
 
       # Transliteration trick from:
       #  https://github.com/cubing/worldcubeassociation.org/issues/238#issuecomment-234702800
-      transliterated = text.mb_chars.normalize(:kd).gsub(/[\p{Mn}]/,'').to_s
-      transliterated = transliterated.gsub "ł", "l"
-      transliterated = transliterated.gsub "Ł", "L"
+      transliterated = text.chars.map { |ch| transliterate_char(ch) }.join
 
       previous_match_end_index = 0
       result = ""
@@ -39,4 +37,21 @@ module Translighterate
       result += text[previous_match_end_index..-1]
     end.html_safe
   end
+end
+
+def transliterate_char(ch)
+  raise if ch.length != 1
+
+  mappings = {
+    "ł" => "l",
+    "Ł" => "L",
+  }
+
+  ch = if mappings.key?(ch)
+         mappings[ch]
+       else
+         ch.mb_chars.normalize(:kd).gsub(/[\p{Mn}]/, '').normalize(:c).to_s
+       end
+  raise if ch.length != 1
+  ch
 end

--- a/spec/translighterate_spec.rb
+++ b/spec/translighterate_spec.rb
@@ -36,6 +36,10 @@ RSpec.describe Translighterate do
     expect(Translighterate.highlight("Yu Nakajima (中島悠)", "中")).to eq "Yu Nakajima (<mark>中</mark>島悠)"
   end
 
+  it "handles characters whose kd normalization form is multiple spacing marks" do
+    expect(Translighterate.highlight("이 wins", "wins")).to eq "이 <mark>wins</mark>"
+  end
+
   context "when a regexp is given" do
     it "highlights everything matching it" do
       expect(Translighterate.highlight("Yu Nakajima (中島悠)", /(中|(y.))/i)).to eq "<mark>Yu</mark> Nakajima (<mark>中</mark>島悠)"


### PR DESCRIPTION
Hey @jonatanklosko and @oyyq99999, could you take a look at this?

This is causing a crash on the WCA website here: https://www.worldcubeassociation.org/search?q=fmc+asia

Some more details on what happens to `이` when normalizing to `:nkfd`:

```python
>>> ch = '이'
>>> len(ch)
1
>>> normalized = unicodedata.normalize("NFKD", ch)
>>> len(normalized)
2
>>> normalized
'ᄋ'
>>> hex(ord(normalized[0]))
'0x110b' # <http://www.unicodemap.org/details/0x110b/index.html>
>>> hex(ord(normalized[1]))
'0x1175' # <http://www.unicodemap.org/details/0x1175/index.html>
```

Neither of these characters match the `[\p{Mn}]` regex, so they don't get replaced, and we end up with a 2 character string. By re-normalizing to NFC at the end, they at least get combined back into one character, which means our later scan still works.