### PR TITLE
Fix transliterate for some Thaï characters

### DIFF
--- a/lib/translighterate.rb
+++ b/lib/translighterate.rb
@@ -41,6 +41,7 @@ end
 
 def transliterate_char(ch)
   raise if ch.length != 1
+  original_char = ch
 
   mappings = {
     "ł" => "l",
@@ -52,6 +53,9 @@ def transliterate_char(ch)
        else
          ch.mb_chars.normalize(:kd).gsub(/[\p{Mn}]/, '').normalize(:c).to_s
        end
-  raise if ch.length != 1
-  ch
+  if ch.length != 1
+    original_char
+  else
+    ch
+  end
 end

--- a/spec/translighterate_spec.rb
+++ b/spec/translighterate_spec.rb
@@ -30,10 +30,12 @@ RSpec.describe Translighterate do
   it "preserves special characters" do
     expect(Translighterate.highlight("Yu Nakajima (中島悠)", "yu")).to eq "<mark>Yu</mark> Nakajima (中島悠)"
     expect(Translighterate.highlight("zasięg", "something else")).to eq "zasięg"
+    expect(Translighterate.highlight("Piti Pichedpan (ปิติ พิเชษฐพันธ์)", "piti")).to eq "<mark>Piti</mark> Pichedpan (ปิติ พิเชษฐพันธ์)"
   end
 
   it "matches special characters" do
     expect(Translighterate.highlight("Yu Nakajima (中島悠)", "中")).to eq "Yu Nakajima (<mark>中</mark>島悠)"
+    expect(Translighterate.highlight("Piti Pichedpan (ปิติ พิเชษฐพันธ์)", "ติ")).to eq "Piti Pichedpan (ปิ<mark>ติ</mark> พิเชษฐพันธ์)"
   end
 
   it "handles characters whose kd normalization form is multiple spacing marks" do


### PR DESCRIPTION
I ran into a weird error on the website [using the search page](https://www.worldcubeassociation.org/search?q=kanneti), I tracked it down to the Translighterate gem.

On some characters the `transliterate_char` throw a RuntimeError:
>irb(main):006:0> text="คั"
=> "คั"
irb(main):007:0> text.chars
=> ["ค", "ั"]
irb(main):012:0> text.chars.map { |c| puts c; transliterate_char(c) }
ค
>
>RuntimeError: 
	from (irb):12:in `block in irb_binding'
	from (irb):12:in `map'
	from (irb):12

Somehow this "one" character is made from a character and an accent if I get right, but using the second one on his own is pretty much using a blank character, and `transliterate_char` throw an error.
Since these chars don't transliterate, we might as well rescue the error and return the original char.

I've tested the fix locally by putting my repo on the Gemfile, and it works nicely.