### PR TITLE
Migrate dependencies to Rails 6

### DIFF
--- a/lib/translighterate.rb
+++ b/lib/translighterate.rb
@@ -51,7 +51,7 @@ def transliterate_char(ch)
   ch = if mappings.key?(ch)
          mappings[ch]
        else
-         ch.mb_chars.normalize(:kd).gsub(/[\p{Mn}]/, '').normalize(:c).to_s
+         ch.mb_chars.unicode_normalize(:nfkd).gsub(/[\p{Mn}]/, '').unicode_normalize(:nfc).to_s
        end
   if ch.length != 1
     original_char

--- a/translighterate.gemspec
+++ b/translighterate.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "actionview", ">= 4.0"
+  spec.add_dependency "actionview", ">= 6.0"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/translighterate.gemspec
+++ b/translighterate.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "actionview", ">= 4.0", "< 6.0"
+  spec.add_dependency "actionview", ">= 4.0"
 
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
In Rails 6, the `normalize` function has been deprecated as per https://github.com/rails/rails/pull/34202. This PR aims to provide a version of `translighterate` that is compatible with Rails 6+.

The names of the noramlization forms have also slightly changed, where `nf` simply stands for "normal form". So `:c` becomes `:nfc` and so on.